### PR TITLE
feat(health-checker)_: add alchemy provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Run the complete system:
    
    # Generate default_providers.json with different authentication methods
    python3 rpc-health-checker/generate_providers.py \
-     --providers infura:YOUR_INFURA_TOKEN grove:YOUR_GROVE_TOKEN status_network \
+     --providers infura:YOUR_INFURA_TOKEN grove:YOUR_GROVE_TOKEN alchemy:YOUR_ALCHEMY_TOKEN status_network \
      --networks mainnet sepolia \
      --chains ethereum optimism arbitrum base status \
      --output secrets/default_providers.json
    
    # Or use mix of token, basic auth, and no-auth providers
    python3 rpc-health-checker/generate_providers.py \
-     --providers infura:YOUR_INFURA_TOKEN grove:username:password status_network \
+     --providers infura:YOUR_INFURA_TOKEN grove:username:password alchemy:YOUR_ALCHEMY_TOKEN status_network \
      --networks mainnet sepolia \
      --chains ethereum optimism arbitrum base status \
      --output secrets/default_providers.json
@@ -32,7 +32,7 @@ Run the complete system:
    # Generate reference_providers.json with single provider per chain
    python3 rpc-health-checker/generate_providers.py \
      --single-provider \
-     --providers infura:YOUR_INFURA_TOKEN_REFERENCE status_network \
+     --providers infura:YOUR_INFURA_TOKEN_REFERENCE alchemy:YOUR_ALCHEMY_TOKEN status_network \
      --networks mainnet sepolia \
      --chains ethereum optimism arbitrum base status \
      --output secrets/reference_providers.json
@@ -40,13 +40,14 @@ Run the complete system:
    Please replace:
    - `YOUR_INFURA_TOKEN` and `YOUR_INFURA_TOKEN_REFERENCE` with your Infura API tokens
    - `YOUR_GROVE_TOKEN` with your Grove API token, or use `username:password` for basic auth
+   - `YOUR_ALCHEMY_TOKEN` with your Alchemy API token
    - Other provider credentials as needed
 
    **Note**: `--providers` accepts multiple providers with different authentication methods:
    - No auth format: just provider name (e.g., `status_network`)
-   - Token auth format: `provider:token` (e.g., `infura:abc123`)
+   - Token auth format: `provider:token` (e.g., `infura:abc123`, `alchemy:xyz789`)
    - Basic auth format: `provider:username:password` (e.g., `grove:user:pass`)
-   - Example: `--providers infura:TOKEN1 grove:user:pass status_network nodefleet:TOKEN2`
+   - Example: `--providers infura:TOKEN1 grove:user:pass status_network nodefleet:TOKEN2 alchemy:TOKEN3`
 
 2. Create .htpasswd file for nginx proxy authentication:
    ```bash

--- a/rpc-health-checker/generate_providers.py
+++ b/rpc-health-checker/generate_providers.py
@@ -6,6 +6,7 @@ INFURA = "infura"
 GROVE = "grove"
 NODEFLEET = "nodefleet"
 STATUS_NETWORK = "status_network"
+ALCHEMY = "alchemy"
 
 NETWORK_DATA = [
     {
@@ -15,7 +16,8 @@ NETWORK_DATA = [
         "providers": {
             INFURA: "https://mainnet.infura.io/v3/",
             GROVE: "https://eth.rpc.grove.city/v1/",
-            NODEFLEET: "https://eth-mainnet.alphafleet.io/"
+            NODEFLEET: "https://eth-mainnet.alphafleet.io/",
+            ALCHEMY: "https://eth-mainnet.g.alchemy.com/v2/"
         }
     },
     {
@@ -25,7 +27,8 @@ NETWORK_DATA = [
         "providers": {
             INFURA: "https://sepolia.infura.io/v3/",
             GROVE: "https://eth-sepolia-testnet.rpc.grove.city/v1/",
-            NODEFLEET: "https://eth-sepolia.alphafleet.io/"
+            NODEFLEET: "https://eth-sepolia.alphafleet.io/",
+            ALCHEMY: "https://eth-sepolia.g.alchemy.com/v2/"
         }
     },
     {
@@ -35,7 +38,8 @@ NETWORK_DATA = [
         "providers": {
             INFURA: "https://optimism-mainnet.infura.io/v3/",
             GROVE: "https://optimism.rpc.grove.city/v1/",
-            NODEFLEET: "https://optimism-mainnet.alphafleet.io/"
+            NODEFLEET: "https://optimism-mainnet.alphafleet.io/",
+            ALCHEMY: "https://opt-mainnet.g.alchemy.com/v2/"
         }
     },
     {
@@ -45,7 +49,8 @@ NETWORK_DATA = [
         "providers": {
             INFURA: "https://optimism-sepolia.infura.io/v3/",
             GROVE: "https://optimism-sepolia-testnet.rpc.grove.city/v1/",
-            NODEFLEET: "https://optimism-sepolia.alphafleet.io/"
+            NODEFLEET: "https://optimism-sepolia.alphafleet.io/",
+            ALCHEMY: "https://opt-sepolia.g.alchemy.com/v2/"
         }
     },
     {
@@ -55,7 +60,8 @@ NETWORK_DATA = [
         "providers": {
             INFURA: "https://arbitrum-mainnet.infura.io/v3/",
             GROVE: "https://arbitrum-one.rpc.grove.city/v1/",
-            NODEFLEET: "https://arb-mainnet.alphafleet.io/"
+            NODEFLEET: "https://arb-mainnet.alphafleet.io/",
+            ALCHEMY: "https://arb-mainnet.g.alchemy.com/v2/"
         }
     },
     {
@@ -65,7 +71,8 @@ NETWORK_DATA = [
         "providers": {
             INFURA: "https://arbitrum-sepolia.infura.io/v3/",
             GROVE: "https://arbitrum-sepolia-testnet.rpc.grove.city/v1/",
-            NODEFLEET: "https://arb-sepolia.alphafleet.io/"
+            NODEFLEET: "https://arb-sepolia.alphafleet.io/",
+            ALCHEMY: "https://arb-sepolia.g.alchemy.com/v2/"
         }
     },
     {
@@ -75,7 +82,8 @@ NETWORK_DATA = [
         "providers": {
             INFURA: "https://base-mainnet.infura.io/v3/",
             GROVE: "https://base.rpc.grove.city/v1/",
-            NODEFLEET: "https://base-mainnet.alphafleet.io/"
+            NODEFLEET: "https://base-mainnet.alphafleet.io/",
+            ALCHEMY: "https://base-mainnet.g.alchemy.com/v2/"
         }
     },
     {
@@ -85,7 +93,8 @@ NETWORK_DATA = [
         "providers": {
             INFURA: "https://base-sepolia.infura.io/v3/",
             GROVE: "https://base-testnet.rpc.grove.city/v1/",
-            NODEFLEET: "https://base-sepolia.alphafleet.io/"
+            NODEFLEET: "https://base-sepolia.alphafleet.io/",
+            ALCHEMY: "https://base-sepolia.g.alchemy.com/v2/"
         }
     },
     {


### PR DESCRIPTION
Added endpoints for alchemy to `generate_providers.py`

```
   # Or use mix of token, basic auth, and no-auth providers
   python3 rpc-health-checker/generate_providers.py \
     --providers infura:YOUR_INFURA_TOKEN grove:username:password alchemy:YOUR_ALCHEMY_TOKEN status_network \
     --networks mainnet sepolia \
     --chains ethereum optimism arbitrum base status \
     --output secrets/default_providers.json
     
   # Generate reference_providers.json with single provider per chain
   python3 rpc-health-checker/generate_providers.py \
     --single-provider \
     --providers infura:YOUR_INFURA_TOKEN_REFERENCE alchemy:YOUR_ALCHEMY_TOKEN status_network \
     --networks mainnet sepolia \
     --chains ethereum optimism arbitrum base status \
     --output secrets/reference_providers.json
```

fixes #17