### PR TITLE
Add chains: Linea, Blast, ZkSync, Mantle, Abstract, Unichain

### DIFF
--- a/rpc-health-checker/generate_providers.py
+++ b/rpc-health-checker/generate_providers.py
@@ -98,6 +98,28 @@ NETWORK_DATA = [
         }
     },
     {
+        "chain": "linea",
+        "network": "mainnet",
+        "chainId": 59144,
+        "providers": {
+            INFURA: "https://linea-mainnet.infura.io/v3/",
+            GROVE: "https://linea.rpc.grove.city/v1/",
+            NODEFLEET: "https://linea-mainnet.alphafleet.io/",
+            ALCHEMY: "https://linea-mainnet.g.alchemy.com/v2/",
+        },
+    },
+    {
+        "chain": "linea",
+        "network": "sepolia",
+        "chainId": 59141,
+        "providers": {
+            INFURA: "https://linea-sepolia.infura.io/v3/",
+            GROVE: "https://linea-testnet.rpc.grove.city/v1/",
+            NODEFLEET: "https://linea-sepolia.alphafleet.io/",
+            ALCHEMY: "https://linea-sepolia.g.alchemy.com/v2/",
+        },
+    },
+    {
         "chain": "status",
         "network": "sepolia",
         "chainId": 1660990954,

--- a/rpc-health-checker/generate_providers.py
+++ b/rpc-health-checker/generate_providers.py
@@ -142,7 +142,7 @@ NETWORK_DATA = [
         }
     },
     {
-        "chain": "zksync-era",
+        "chain": "zksync",
         "network": "mainnet",
         "chainId": 324,
         "providers": {
@@ -153,7 +153,7 @@ NETWORK_DATA = [
         }
     },
     {
-        "chain": "zksync-era",
+        "chain": "zksync",
         "network": "sepolia",
         "chainId": 300,
         "providers": {
@@ -163,12 +163,72 @@ NETWORK_DATA = [
             ALCHEMY: "https://zksync-sepolia.g.alchemy.com/v2/"
         }
     },
-
-
-# ZkSync
-# Mantle Era
-# Abstract and
-# Unichain
+    {
+        "chain": "mantle",
+        "network": "mainnet",
+        "chainId": 5000,
+        "providers": {
+            INFURA: "https://mantle-mainnet.infura.io/v3/",
+            GROVE: "https://mantle.rpc.grove.city/v1/",
+            NODEFLEET: "https://mantle-mainnet.alphafleet.io/",
+            ALCHEMY: "https://mantle-mainnet.g.alchemy.com/v2/"
+        }
+    },
+    {
+        "chain": "mantle",
+        "network": "sepolia",
+        "chainId": 5003,
+        "providers": {
+            INFURA: "https://mantle-sepolia.infura.io/v3/",
+            GROVE: "",
+            NODEFLEET: "https://mantle-sepolia.alphafleet.io/",
+            ALCHEMY: "https://mantle-sepolia.g.alchemy.com/v2/"
+        }
+    },
+    {
+        "chain": "abstract",
+        "network": "mainnet",
+        "chainId": 2741,
+        "providers": {
+            INFURA: "",
+            GROVE: "",
+            NODEFLEET: "https://abstract-mainnet.alphafleet.io/",
+            ALCHEMY: "https://abstract-mainnet.g.alchemy.com/v2/"
+        }
+    },
+    {
+        "chain": "abstract",
+        "network": "testnet",
+        "chainId": 11124,
+        "providers": {
+            INFURA: "",
+            GROVE: "",
+            NODEFLEET: "https://abstract-testnet.alphafleet.io/",
+            ALCHEMY: "https://abstract-testnet.g.alchemy.com/v2/"
+        }
+    },
+    {
+        "chain": "unichain",
+        "network": "mainnet",
+        "chainId": 130,
+        "providers": {
+            INFURA: "https://unichain-mainnet.infura.io/v3/",
+            GROVE: "",
+            NODEFLEET: "https://unichain-mainnet.alphafleet.io/",
+            ALCHEMY: "https://unichain-mainnet.g.alchemy.com/v2/"
+        }
+    },
+    {
+        "chain": "unichain",
+        "network": "sepolia",
+        "chainId": 1301,
+        "providers": {
+            INFURA: "https://unichain-sepolia.infura.io/v3/",
+            GROVE: "",
+            NODEFLEET: "https://unichain-sepolia.alphafleet.io/",
+            ALCHEMY: "https://unichain-sepolia.g.alchemy.com/v2/"
+        }
+    },
     {
         "chain": "status",
         "network": "sepolia",

--- a/rpc-health-checker/generate_providers.py
+++ b/rpc-health-checker/generate_providers.py
@@ -114,11 +114,61 @@ NETWORK_DATA = [
         "chainId": 59141,
         "providers": {
             INFURA: "https://linea-sepolia.infura.io/v3/",
-            GROVE: "https://linea-testnet.rpc.grove.city/v1/",
+            GROVE: "",
             NODEFLEET: "https://linea-sepolia.alphafleet.io/",
             ALCHEMY: "https://linea-sepolia.g.alchemy.com/v2/",
-        },
+        }
     },
+    {
+        "chain": "blast",
+        "network": "mainnet",
+        "chainId": 81457,
+        "providers": {
+            INFURA: "https://blast-mainnet.infura.io/v3/",
+            GROVE: "https://blast.rpc.grove.city/v1/",
+            NODEFLEET: "https://blast-mainnet.alphafleet.io/",
+            ALCHEMY: "https://blast-mainnet.g.alchemy.com/v2/"
+        }
+    },
+    {
+        "chain": "blast",
+        "network": "sepolia",
+        "chainId": 168587773,
+        "providers": {
+            INFURA: "https://blast-sepolia.infura.io/v3/",
+            GROVE: "",
+            NODEFLEET: "https://blast-sepolia.alphafleet.io/",
+            ALCHEMY: "https://blast-sepolia.g.alchemy.com/v2/"
+        }
+    },
+    {
+        "chain": "zksync-era",
+        "network": "mainnet",
+        "chainId": 324,
+        "providers": {
+            INFURA: "https://zksync-mainnet.infura.io/v3/",
+            GROVE: "https://zksync-era.rpc.grove.city/v1/",
+            NODEFLEET: "https://zksync-era-mainnet.alphafleet.io/",
+            ALCHEMY: "https://zksync-mainnet.g.alchemy.com/v2/"
+        }
+    },
+    {
+        "chain": "zksync-era",
+        "network": "sepolia",
+        "chainId": 300,
+        "providers": {
+            INFURA: "https://zksync-sepolia.infura.io/v3/",
+            GROVE: "",
+            NODEFLEET: "https://zksync-era-sepolia.alphafleet.io/",
+            ALCHEMY: "https://zksync-sepolia.g.alchemy.com/v2/"
+        }
+    },
+
+
+# ZkSync
+# Mantle Era
+# Abstract and
+# Unichain
     {
         "chain": "status",
         "network": "sepolia",

--- a/rpc-health-checker/generate_providers.py
+++ b/rpc-health-checker/generate_providers.py
@@ -114,7 +114,6 @@ NETWORK_DATA = [
         "chainId": 59141,
         "providers": {
             INFURA: "https://linea-sepolia.infura.io/v3/",
-            GROVE: "",
             NODEFLEET: "https://linea-sepolia.alphafleet.io/",
             ALCHEMY: "https://linea-sepolia.g.alchemy.com/v2/",
         }
@@ -136,7 +135,6 @@ NETWORK_DATA = [
         "chainId": 168587773,
         "providers": {
             INFURA: "https://blast-sepolia.infura.io/v3/",
-            GROVE: "",
             NODEFLEET: "https://blast-sepolia.alphafleet.io/",
             ALCHEMY: "https://blast-sepolia.g.alchemy.com/v2/"
         }
@@ -158,7 +156,6 @@ NETWORK_DATA = [
         "chainId": 300,
         "providers": {
             INFURA: "https://zksync-sepolia.infura.io/v3/",
-            GROVE: "",
             NODEFLEET: "https://zksync-era-sepolia.alphafleet.io/",
             ALCHEMY: "https://zksync-sepolia.g.alchemy.com/v2/"
         }
@@ -180,7 +177,6 @@ NETWORK_DATA = [
         "chainId": 5003,
         "providers": {
             INFURA: "https://mantle-sepolia.infura.io/v3/",
-            GROVE: "",
             NODEFLEET: "https://mantle-sepolia.alphafleet.io/",
             ALCHEMY: "https://mantle-sepolia.g.alchemy.com/v2/"
         }
@@ -190,8 +186,6 @@ NETWORK_DATA = [
         "network": "mainnet",
         "chainId": 2741,
         "providers": {
-            INFURA: "",
-            GROVE: "",
             NODEFLEET: "https://abstract-mainnet.alphafleet.io/",
             ALCHEMY: "https://abstract-mainnet.g.alchemy.com/v2/"
         }
@@ -201,8 +195,6 @@ NETWORK_DATA = [
         "network": "testnet",
         "chainId": 11124,
         "providers": {
-            INFURA: "",
-            GROVE: "",
             NODEFLEET: "https://abstract-testnet.alphafleet.io/",
             ALCHEMY: "https://abstract-testnet.g.alchemy.com/v2/"
         }
@@ -213,7 +205,6 @@ NETWORK_DATA = [
         "chainId": 130,
         "providers": {
             INFURA: "https://unichain-mainnet.infura.io/v3/",
-            GROVE: "",
             NODEFLEET: "https://unichain-mainnet.alphafleet.io/",
             ALCHEMY: "https://unichain-mainnet.g.alchemy.com/v2/"
         }
@@ -224,7 +215,6 @@ NETWORK_DATA = [
         "chainId": 1301,
         "providers": {
             INFURA: "https://unichain-sepolia.infura.io/v3/",
-            GROVE: "",
             NODEFLEET: "https://unichain-sepolia.alphafleet.io/",
             ALCHEMY: "https://unichain-sepolia.g.alchemy.com/v2/"
         }

--- a/rpc-health-checker/generate_providers.py
+++ b/rpc-health-checker/generate_providers.py
@@ -114,7 +114,6 @@ NETWORK_DATA = [
         "chainId": 59141,
         "providers": {
             INFURA: "https://linea-sepolia.infura.io/v3/",
-            NODEFLEET: "https://linea-sepolia.alphafleet.io/",
             ALCHEMY: "https://linea-sepolia.g.alchemy.com/v2/",
         }
     },
@@ -135,7 +134,6 @@ NETWORK_DATA = [
         "chainId": 168587773,
         "providers": {
             INFURA: "https://blast-sepolia.infura.io/v3/",
-            NODEFLEET: "https://blast-sepolia.alphafleet.io/",
             ALCHEMY: "https://blast-sepolia.g.alchemy.com/v2/"
         }
     },
@@ -146,7 +144,6 @@ NETWORK_DATA = [
         "providers": {
             INFURA: "https://zksync-mainnet.infura.io/v3/",
             GROVE: "https://zksync-era.rpc.grove.city/v1/",
-            NODEFLEET: "https://zksync-era-mainnet.alphafleet.io/",
             ALCHEMY: "https://zksync-mainnet.g.alchemy.com/v2/"
         }
     },
@@ -156,7 +153,6 @@ NETWORK_DATA = [
         "chainId": 300,
         "providers": {
             INFURA: "https://zksync-sepolia.infura.io/v3/",
-            NODEFLEET: "https://zksync-era-sepolia.alphafleet.io/",
             ALCHEMY: "https://zksync-sepolia.g.alchemy.com/v2/"
         }
     },
@@ -167,7 +163,6 @@ NETWORK_DATA = [
         "providers": {
             INFURA: "https://mantle-mainnet.infura.io/v3/",
             GROVE: "https://mantle.rpc.grove.city/v1/",
-            NODEFLEET: "https://mantle-mainnet.alphafleet.io/",
             ALCHEMY: "https://mantle-mainnet.g.alchemy.com/v2/"
         }
     },
@@ -177,7 +172,6 @@ NETWORK_DATA = [
         "chainId": 5003,
         "providers": {
             INFURA: "https://mantle-sepolia.infura.io/v3/",
-            NODEFLEET: "https://mantle-sepolia.alphafleet.io/",
             ALCHEMY: "https://mantle-sepolia.g.alchemy.com/v2/"
         }
     },
@@ -186,7 +180,6 @@ NETWORK_DATA = [
         "network": "mainnet",
         "chainId": 2741,
         "providers": {
-            NODEFLEET: "https://abstract-mainnet.alphafleet.io/",
             ALCHEMY: "https://abstract-mainnet.g.alchemy.com/v2/"
         }
     },
@@ -195,7 +188,6 @@ NETWORK_DATA = [
         "network": "testnet",
         "chainId": 11124,
         "providers": {
-            NODEFLEET: "https://abstract-testnet.alphafleet.io/",
             ALCHEMY: "https://abstract-testnet.g.alchemy.com/v2/"
         }
     },
@@ -205,7 +197,6 @@ NETWORK_DATA = [
         "chainId": 130,
         "providers": {
             INFURA: "https://unichain-mainnet.infura.io/v3/",
-            NODEFLEET: "https://unichain-mainnet.alphafleet.io/",
             ALCHEMY: "https://unichain-mainnet.g.alchemy.com/v2/"
         }
     },
@@ -215,7 +206,6 @@ NETWORK_DATA = [
         "chainId": 1301,
         "providers": {
             INFURA: "https://unichain-sepolia.infura.io/v3/",
-            NODEFLEET: "https://unichain-sepolia.alphafleet.io/",
             ALCHEMY: "https://unichain-sepolia.g.alchemy.com/v2/"
         }
     },


### PR DESCRIPTION
Fixes mobile issue: [Add new RPC endpoints to Status-Go Proxy](https://github.com/status-im/status-mobile/issues/22311)

## Changes

Added chains:
- linea
- Blast
- ZkSync (Era)
- Mantle Era
- Abstract
- Unichain

## Reviewer notes
Infura and Alchemy and Gtove endpoints where checked manually on respective sites. When no endpoints found empty string left as a value.
**Nodefleet** endpoints where guessed by structure, which mean they **probably incorrect**. Unfortunately i don't know where to find them.
