### PR TITLE
fix(prometheus)_: reduce metrics cardinality

### DIFF
--- a/grafana/provisioning/dashboards/rpc-metrics.json
+++ b/grafana/provisioning/dashboards/rpc-metrics.json
@@ -76,7 +76,7 @@
       "targets": [
         {
           "expr": "provider_status",
-          "legendFormat": "{{provider_name}} ({{chain_name}})",
+          "legendFormat": "{{provider_name}} (Chain {{chain_id}})",
           "refId": "A"
         }
       ]
@@ -308,12 +308,12 @@
           "sort": "desc"
         }
       },
-      "title": "Requests by Chain/Token (Cost Estimation)",
+      "title": "Requests by Chain",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by(chain_id, auth_token_masked) (rate(rpc_requests_total[5m]) * 60)",
-          "legendFormat": "Chain {{chain_id}} - {{auth_token_masked}}",
+          "expr": "sum by(chain_id) (rate(rpc_requests_total[5m]) * 60)",
+          "legendFormat": "Chain {{chain_id}}",
           "refId": "A"
         }
       ]
@@ -379,12 +379,12 @@
           "sort": "desc"
         }
       },
-      "title": "Error Breakdown by Provider",
+      "title": "Error Breakdown by Type",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by(provider_name, request_err) (increase(rpc_requests_total{request_err!='none'}[5m]))",
-          "legendFormat": "{{provider_name}} - {{request_err}}",
+          "expr": "sum by(error_type) (increase(rpc_requests_total{error_type!='none'}[5m]))",
+          "legendFormat": "{{error_type}}",
           "refId": "A"
         }
       ]
@@ -450,18 +450,13 @@
           "sort": "desc"
         }
       },
-      "title": "HTTP Status Codes & EVM Errors by Provider",
+      "title": "Status Codes by Provider",
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by(provider_name, http_status) (increase(rpc_requests_total{http_status!='200'}[5m]))",
-          "legendFormat": "{{provider_name}} - HTTP {{http_status}}",
+          "expr": "sum by(provider_name, status_code) (increase(rpc_requests_total{status_code!='0'}[5m]))",
+          "legendFormat": "{{provider_name}} - {{status_code}}",
           "refId": "A"
-        },
-        {
-          "expr": "sum by(provider_name, evm_error_code) (increase(rpc_requests_total{evm_error_code!='0'}[5m]))",
-          "legendFormat": "{{provider_name}} - EVM Error {{evm_error_code}}",
-          "refId": "B"
         }
       ]
     }

--- a/grafana/provisioning/dashboards/rpc-metrics.json
+++ b/grafana/provisioning/dashboards/rpc-metrics.json
@@ -454,7 +454,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by(provider_name, status_code) (increase(rpc_requests_total{status_code!='0'}[5m]))",
+          "expr": "sum by(provider_name, status_code) (increase(rpc_requests_total{status_code!='success'}[5m]))",
           "legendFormat": "{{provider_name}} - {{status_code}}",
           "refId": "A"
         }

--- a/rpc-health-checker/metrics/error_categories.go
+++ b/rpc-health-checker/metrics/error_categories.go
@@ -1,0 +1,64 @@
+package metrics
+
+// ErrorCategory represents a categorized error type for RPC requests
+type ErrorCategory string
+
+const (
+	// NoError indicates a successful request
+	NoError ErrorCategory = "none"
+
+	// NetworkError indicates network-related issues (timeouts, connection resets, etc.)
+	NetworkError ErrorCategory = "network_error"
+
+	// HTTPError indicates HTTP-level errors (non-200 status codes)
+	HTTPError ErrorCategory = "http_error"
+
+	// JSONRPCError indicates JSON-RPC protocol errors
+	JSONRPCError ErrorCategory = "jsonrpc_error"
+
+	// EVMError indicates EVM-specific errors (non-zero EVM error codes)
+	EVMError ErrorCategory = "evm_error"
+
+	// UnknownError indicates unclassified errors
+	UnknownError ErrorCategory = "unknown_error"
+)
+
+// CategorizeError takes an error and returns the appropriate ErrorCategory
+func CategorizeError(err error, httpStatus, evmErrorCode int) ErrorCategory {
+	if err == nil {
+		return NoError
+	}
+
+	errStr := err.Error()
+
+	// Check for network-related errors
+	if errStr == "context deadline exceeded" ||
+		errStr == "context canceled" ||
+		errStr == "connection reset by peer" ||
+		errStr == "connection refused" ||
+		errStr == "no such host" ||
+		errStr == "i/o timeout" {
+		return NetworkError
+	}
+
+	// Check for HTTP errors
+	if httpStatus != 0 && httpStatus != 200 {
+		return HTTPError
+	}
+
+	// Check for EVM errors
+	if evmErrorCode != 0 {
+		return EVMError
+	}
+
+	// Check for JSON-RPC errors
+	if errStr == "invalid json" ||
+		errStr == "invalid request" ||
+		errStr == "method not found" ||
+		errStr == "invalid params" {
+		return JSONRPCError
+	}
+
+	// Default to unknown error
+	return UnknownError
+}

--- a/rpc-health-checker/metrics/error_categories_test.go
+++ b/rpc-health-checker/metrics/error_categories_test.go
@@ -1,0 +1,133 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestCategorizeError(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		httpStatus   int
+		evmErrorCode int
+		want         ErrorCategory
+	}{
+		{
+			name:         "nil error",
+			err:          nil,
+			httpStatus:   0,
+			evmErrorCode: 0,
+			want:         NoError,
+		},
+		{
+			name:         "network timeout",
+			err:          &timeoutError{},
+			httpStatus:   0,
+			evmErrorCode: 0,
+			want:         NetworkError,
+		},
+		{
+			name:         "connection refused",
+			err:          errors.New("connection refused"),
+			httpStatus:   0,
+			evmErrorCode: 0,
+			want:         NetworkError,
+		},
+		{
+			name:         "connection reset",
+			err:          errors.New("connection reset"),
+			httpStatus:   0,
+			evmErrorCode: 0,
+			want:         NetworkError,
+		},
+		{
+			name:         "context deadline exceeded",
+			err:          context.DeadlineExceeded,
+			httpStatus:   0,
+			evmErrorCode: 0,
+			want:         NetworkError,
+		},
+		{
+			name:         "context canceled",
+			err:          context.Canceled,
+			httpStatus:   0,
+			evmErrorCode: 0,
+			want:         NetworkError,
+		},
+		{
+			name:         "http error 400",
+			err:          nil,
+			httpStatus:   http.StatusBadRequest,
+			evmErrorCode: 0,
+			want:         HTTPError,
+		},
+		{
+			name:         "http error 500",
+			err:          nil,
+			httpStatus:   http.StatusInternalServerError,
+			evmErrorCode: 0,
+			want:         HTTPError,
+		},
+		{
+			name:         "jsonrpc invalid request",
+			err:          nil,
+			httpStatus:   0,
+			evmErrorCode: JSONRPCInvalidRequest,
+			want:         JSONRPCError,
+		},
+		{
+			name:         "jsonrpc method not found",
+			err:          nil,
+			httpStatus:   0,
+			evmErrorCode: JSONRPCMethodNotFound,
+			want:         JSONRPCError,
+		},
+		{
+			name:         "jsonrpc invalid params",
+			err:          nil,
+			httpStatus:   0,
+			evmErrorCode: JSONRPCInvalidParams,
+			want:         JSONRPCError,
+		},
+		{
+			name:         "jsonrpc parse error",
+			err:          nil,
+			httpStatus:   0,
+			evmErrorCode: JSONRPCParseError,
+			want:         JSONRPCError,
+		},
+		{
+			name:         "evm error",
+			err:          nil,
+			httpStatus:   0,
+			evmErrorCode: -32000,
+			want:         EVMError,
+		},
+		{
+			name:         "unknown error",
+			err:          errors.New("some unknown error"),
+			httpStatus:   0,
+			evmErrorCode: 0,
+			want:         UnknownError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CategorizeError(tt.err, tt.httpStatus, tt.evmErrorCode)
+			if got != tt.want {
+				t.Errorf("CategorizeError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// timeoutError implements net.Error interface
+type timeoutError struct{}
+
+func (e *timeoutError) Error() string   { return "timeout" }
+func (e *timeoutError) Timeout() bool   { return true }
+func (e *timeoutError) Temporary() bool { return true }

--- a/rpc-health-checker/metrics/metrics.go
+++ b/rpc-health-checker/metrics/metrics.go
@@ -9,6 +9,8 @@ import (
 )
 
 var (
+
+	// cardinality: 1
 	validationCycleDuration = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name: "validation_cycle_duration_seconds",
 		Help: "Duration of validation cycle in seconds",
@@ -19,19 +21,15 @@ var (
 		Help: "Status of providers (1 = working, 0 = not working)",
 	}, []string{"chain_id", "chain_name", "network_name", "provider_name", "provider_url", "auth_token_masked"})
 
+	// approximate cardinality: 10 (chain_id) × 10 (provider_name) × 6 (error_type) × 20 (status_code) = 12k
 	rpcRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "rpc_requests_total",
 		Help: "Total number of RPC requests made for validation checks",
 	}, []string{
-		"chain_id",
-		"chain_name",
-		"provider_name",
-		"provider_url",
-		"method",
-		"auth_token_masked",
-		"request_err",    // Error message if request failed, "none" if successful
-		"http_status",    // HTTP status code, "0" if request failed before getting response
-		"evm_error_code", // EVM error code from JSON-RPC response, "0" if successful
+		"chain_id",      // Chain ID for identification
+		"provider_name", // Provider name for identification
+		"error_type",    // Categorized error type (none, network_error, http_error, jsonrpc_error, evm_error, unknown_error)
+		"status_code",   // Combined status code: HTTP status or EVM error code
 	})
 )
 
@@ -78,25 +76,22 @@ type RPCRequestMetrics struct {
 
 // RecordRPCRequest records a single RPC request with its metadata and error information
 func RecordRPCRequest(metrics RPCRequestMetrics) {
-	// Mask the auth token by keeping only first and last 4 characters if it's long enough
-	maskedToken := maskAuthToken(metrics.AuthToken)
+	// Categorize the error
+	errCategory := CategorizeError(metrics.RequestErr, metrics.HTTPStatus, metrics.EVMErrorCode)
 
-	// Format error message, use "none" if no error
-	errMsg := "none"
-	if metrics.RequestErr != nil {
-		errMsg = metrics.RequestErr.Error()
+	// Determine status code based on error type
+	statusCode := "0"
+	if errCategory == HTTPError {
+		statusCode = fmt.Sprintf("http_%d", metrics.HTTPStatus)
+	} else if errCategory == EVMError {
+		statusCode = fmt.Sprintf("evm_%d", metrics.EVMErrorCode)
 	}
 
 	rpcRequestsTotal.WithLabelValues(
 		fmt.Sprintf("%d", metrics.ChainID),
-		metrics.ChainName,
 		metrics.ProviderName,
-		metrics.ProviderURL,
-		metrics.Method,
-		maskedToken,
-		errMsg,
-		fmt.Sprintf("%d", metrics.HTTPStatus),
-		fmt.Sprintf("%d", metrics.EVMErrorCode),
+		string(errCategory),
+		statusCode,
 	).Inc()
 }
 

--- a/rpc-health-checker/metrics/metrics.go
+++ b/rpc-health-checker/metrics/metrics.go
@@ -78,11 +78,17 @@ func RecordRPCRequest(metrics RPCRequestMetrics) {
 	errCategory := CategorizeError(metrics.RequestErr, metrics.HTTPStatus, metrics.EVMErrorCode)
 
 	// Determine status code based on error type
-	statusCode := "0"
+	statusCode := "success" // Default for successful requests
 	if errCategory == HTTPError {
 		statusCode = fmt.Sprintf("http_%d", metrics.HTTPStatus)
 	} else if errCategory == EVMError {
 		statusCode = fmt.Sprintf("evm_%d", metrics.EVMErrorCode)
+	} else if errCategory == JSONRPCError {
+		statusCode = "jsonrpc_error"
+	} else if errCategory == NetworkError {
+		statusCode = "network_error"
+	} else if errCategory == UnknownError {
+		statusCode = "unknown_error"
 	}
 
 	rpcRequestsTotal.WithLabelValues(


### PR DESCRIPTION
- Reduced `rpc_requests_total` cardinality by removing high-cardinality labels and combining status codes
- Simplified `provider_status` to use only `chain_id` and `provider_name`
- Updated Grafana dashboard to match new metric structure

```
count(provider_status) - 69
count(validation_cycle_duration_seconds_count) - 1

Unique values per label in rpc_requests_total:
----------------------------------------
chain_id - 22
provider_name - 7
error_type - 3
status_code - 6
```


Closes #41 