### PR TITLE
fix(health-checker): exclude gas estimation test for linea chain

### DIFF
--- a/rpc-health-checker/config/testconfig.go
+++ b/rpc-health-checker/config/testconfig.go
@@ -13,6 +13,7 @@ type EVMMethodTestConfig struct {
 	Method      string
 	Params      []interface{}
 	CompareFunc func(reference, result *big.Int) bool
+	SkipChains  map[int64]bool // Chains to skip test (chainID -> true)
 }
 
 // EVMMethodTestJSON represents the JSON structure for EVM method test configuration
@@ -20,6 +21,7 @@ type EVMMethodTestJSON struct {
 	Method        string        `json:"method"`
 	Params        []interface{} `json:"params"`
 	MaxDifference string        `json:"maxDifference"`
+	SkipChains    []int64       `json:"skipChains,omitempty"` // Chain IDs to skip test
 }
 
 // ReadConfig reads and parses the EVM method test configuration from a JSON file
@@ -51,10 +53,16 @@ func ReadConfig(path string) ([]EVMMethodTestConfig, error) {
 			return diff.Cmp(maxDiff) <= 0
 		}
 
+		skipChainsMap := make(map[int64]bool)
+		for _, chainID := range cfg.SkipChains {
+			skipChainsMap[chainID] = true
+		}
+
 		configs = append(configs, EVMMethodTestConfig{
 			Method:      cfg.Method,
 			Params:      cfg.Params,
 			CompareFunc: compareFunc,
+			SkipChains:  skipChainsMap,
 		})
 	}
 

--- a/rpc-health-checker/test_methods.json
+++ b/rpc-health-checker/test_methods.json
@@ -43,6 +43,7 @@
         "value": "0x0"
       }
     ],
-    "maxDifference": "100000"
+    "maxDifference": "100000",
+    "skipChains": [59141]
   }
 ]


### PR DESCRIPTION
Before: Infura providers failed on `eth_estimateGas` due to strict balance checking
After: `eth_estimateGas` is skipped for Linea Sepolia, all other tests pass validation

fixes #91 