### PR TITLE
fix(cache): Skip caching null results for pending transactions 

### DIFF
--- a/go-proxy-cache/cache_rules.yaml
+++ b/go-proxy-cache/cache_rules.yaml
@@ -18,6 +18,12 @@ ttl_defaults:
     short: 5s
     minimal: 0s
 
+skip_null_cache:
+  - eth_getTransactionReceipt
+  - eth_getTransactionByHash
+  - eth_getBlockByHash
+  - eth_getBlockByNumber
+
 # Cache rules mapping JSON-RPC methods to cache types
 cache_rules:
   # Permanent cache - blockchain data that never changes

--- a/go-proxy-cache/internal/cache/service/service.go
+++ b/go-proxy-cache/internal/cache/service/service.go
@@ -145,6 +145,15 @@ func (s *CacheService) Set(chain, network, rawBody, responseData string, customT
 		return fmt.Errorf("invalid JSON-RPC request: %w", err)
 	}
 
+	// Skip caching null results for methods configured in skip_null_cache
+	if s.cacheClassifier.ShouldSkipNullCache(request.Method) && utils.IsNullResult(responseData) {
+		s.logger.Debug("Skipping cache for null result",
+			zap.String("method", request.Method),
+			zap.String("chain", chain),
+			zap.String("network", network))
+		return nil
+	}
+
 	// Build cache key
 	key, err := s.keyBuilder.Build(chain, network, request)
 	if err != nil {

--- a/go-proxy-cache/internal/cache_rules/classifier.go
+++ b/go-proxy-cache/internal/cache_rules/classifier.go
@@ -42,3 +42,8 @@ func (c *Classifier) GetTtl(chain, network string, request *models.JSONRPCReques
 
 	return models.CacheInfo{TTL: ttl, CacheType: cacheType}
 }
+
+// ShouldSkipNullCache implements CacheRulesClassifier interface
+func (c *Classifier) ShouldSkipNullCache(method string) bool {
+	return c.configTTL.ShouldSkipNullCache(method)
+}

--- a/go-proxy-cache/internal/cache_rules/types.go
+++ b/go-proxy-cache/internal/cache_rules/types.go
@@ -12,5 +12,6 @@ type TTLDefaults map[models.CacheType]time.Duration
 // CacheRulesConfig represents the cache rules configuration
 type CacheRulesConfig struct {
 	ChainsTTLDefaults map[string]TTLDefaults      `yaml:"ttl_defaults"`
+	SkipNullCache     []string                    `yaml:"skip_null_cache"`
 	CacheRules        map[string]models.CacheType `yaml:"cache_rules"`
 }

--- a/go-proxy-cache/internal/httpserver/server_test.go
+++ b/go-proxy-cache/internal/httpserver/server_test.go
@@ -79,6 +79,18 @@ func setupMockCacheClassifier(ctrl *gomock.Controller) *mock.MockCacheRulesClass
 		},
 	).AnyTimes()
 
+	// Set up ShouldSkipNullCache expectation - return true for methods that should skip null caching
+	mockClassifier.EXPECT().ShouldSkipNullCache(gomock.Any()).DoAndReturn(
+		func(method string) bool {
+			switch method {
+			case "eth_getTransactionReceipt", "eth_getTransactionByHash", "eth_getBlockByHash", "eth_getBlockByNumber":
+				return true
+			default:
+				return false
+			}
+		},
+	).AnyTimes()
+
 	return mockClassifier
 }
 
@@ -406,6 +418,154 @@ func TestServer_HandleSet(t *testing.T) {
 					}
 					if _, found := l2Cache.data[key]; !found {
 						t.Errorf("handleSet() data not found in L2 cache")
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestServer_HandleSet_SkipNullCache verifies that null results for skip-listed methods
+// are not written to L1 or L2 cache
+func TestServer_HandleSet_SkipNullCache(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	logger := zaptest.NewLogger(t)
+	cacheService, l1Cache, l2Cache := setupCacheService(ctrl, logger)
+
+	server := NewServer(cacheService, logger)
+
+	tests := []struct {
+		name             string
+		requestBody      CacheRequest
+		expectedStatus   int
+		expectCached     bool
+		description      string
+	}{
+		{
+			name: "skip-listed method with null result should not cache",
+			requestBody: CacheRequest{
+				Chain:   "ethereum",
+				Network: "mainnet",
+				RawBody: `{"method":"eth_getTransactionReceipt","params":["0x123"],"jsonrpc":"2.0","id":1}`,
+				Data:    `{"jsonrpc":"2.0","id":1,"result":null}`,
+			},
+			expectedStatus: http.StatusOK,
+			expectCached:   false,
+			description:    "eth_getTransactionReceipt with null result should skip caching",
+		},
+		{
+			name: "skip-listed method with non-null result should cache",
+			requestBody: CacheRequest{
+				Chain:   "ethereum",
+				Network: "mainnet",
+				RawBody: `{"method":"eth_getBlockByHash","params":["0x456",true],"jsonrpc":"2.0","id":2}`,
+				Data:    `{"jsonrpc":"2.0","id":2,"result":{"number":"0x123","hash":"0x456"}}`,
+			},
+			expectedStatus: http.StatusOK,
+			expectCached:   true,
+			description:    "eth_getBlockByHash with non-null result should be cached",
+		},
+		{
+			name: "non-skip-listed method with null result should cache",
+			requestBody: CacheRequest{
+				Chain:   "ethereum",
+				Network: "mainnet",
+				RawBody: `{"method":"eth_getBalance","params":["0x789","latest"],"jsonrpc":"2.0","id":3}`,
+				Data:    `{"jsonrpc":"2.0","id":3,"result":null}`,
+			},
+			expectedStatus: http.StatusOK,
+			expectCached:   false, // eth_getBalance has TTL 0 in mock, so won't cache anyway
+			description:    "non-skip-listed method returns based on TTL rules",
+		},
+		{
+			name: "eth_getBlockByHash with null result should not cache",
+			requestBody: CacheRequest{
+				Chain:   "ethereum",
+				Network: "mainnet",
+				RawBody: `{"method":"eth_getBlockByHash","params":["0xnonexistent",true],"jsonrpc":"2.0","id":4}`,
+				Data:    `{"jsonrpc":"2.0","id":4,"result":null}`,
+			},
+			expectedStatus: http.StatusOK,
+			expectCached:   false,
+			description:    "eth_getBlockByHash with null result should skip caching",
+		},
+		{
+			name: "eth_getBlockByNumber with null result should not cache",
+			requestBody: CacheRequest{
+				Chain:   "ethereum",
+				Network: "mainnet",
+				RawBody: `{"method":"eth_getBlockByNumber","params":["0x999999999",true],"jsonrpc":"2.0","id":5}`,
+				Data:    `{"jsonrpc":"2.0","id":5,"result":null}`,
+			},
+			expectedStatus: http.StatusOK,
+			expectCached:   false,
+			description:    "eth_getBlockByNumber with null result should skip caching",
+		},
+		{
+			name: "eth_getTransactionByHash with null result should not cache",
+			requestBody: CacheRequest{
+				Chain:   "ethereum",
+				Network: "mainnet",
+				RawBody: `{"method":"eth_getTransactionByHash","params":["0xpending"],"jsonrpc":"2.0","id":6}`,
+				Data:    `{"jsonrpc":"2.0","id":6,"result":null}`,
+			},
+			expectedStatus: http.StatusOK,
+			expectCached:   false,
+			description:    "eth_getTransactionByHash with null result should skip caching",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset caches before each test
+			l1Cache.data = make(map[string]*models.CacheEntry)
+			l2Cache.data = make(map[string]*models.CacheEntry)
+
+			body, _ := json.Marshal(tt.requestBody)
+			req := httptest.NewRequest("POST", "/cache/set", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+
+			w := httptest.NewRecorder()
+			server.handleSet(w, req)
+
+			if w.Code != tt.expectedStatus {
+				t.Errorf("%s: status = %v, want %v", tt.description, w.Code, tt.expectedStatus)
+			}
+
+			if tt.expectedStatus == http.StatusOK {
+				var response CacheResponse
+				if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+					t.Fatalf("Failed to unmarshal response: %v", err)
+				}
+
+				if !response.Success {
+					t.Errorf("%s: Success = false, want true", tt.description)
+				}
+
+				// Generate cache key to check if data was cached
+				key, err := generateCacheKey(tt.requestBody.Chain, tt.requestBody.Network, tt.requestBody.RawBody)
+				if err != nil {
+					t.Fatalf("Failed to generate cache key: %v", err)
+				}
+
+				_, foundInL1 := l1Cache.data[key]
+				_, foundInL2 := l2Cache.data[key]
+
+				if tt.expectCached {
+					if !foundInL1 {
+						t.Errorf("%s: expected data in L1 cache, but not found", tt.description)
+					}
+					if !foundInL2 {
+						t.Errorf("%s: expected data in L2 cache, but not found", tt.description)
+					}
+				} else {
+					if foundInL1 {
+						t.Errorf("%s: expected L1 cache to be empty, but found data", tt.description)
+					}
+					if foundInL2 {
+						t.Errorf("%s: expected L2 cache to be empty, but found data", tt.description)
 					}
 				}
 			}

--- a/go-proxy-cache/internal/interfaces/cache_rules_classifier.go
+++ b/go-proxy-cache/internal/interfaces/cache_rules_classifier.go
@@ -8,4 +8,6 @@ import "go-proxy-cache/internal/models"
 type CacheRulesClassifier interface {
 	// GetTtl analyzes the request and returns cache information including TTL and cache type
 	GetTtl(chain, network string, request *models.JSONRPCRequest) models.CacheInfo
+	// ShouldSkipNullCache returns true if null results should not be cached for this method
+	ShouldSkipNullCache(method string) bool
 }

--- a/go-proxy-cache/internal/interfaces/cache_rules_config.go
+++ b/go-proxy-cache/internal/interfaces/cache_rules_config.go
@@ -16,4 +16,6 @@ type CacheRulesConfig interface {
 	GetCacheTypeForMethod(method string) models.CacheType
 	// GetAllMethods returns all configured RPC methods
 	GetAllMethods() []string
+	// ShouldSkipNullCache returns true if null results should not be cached for this method
+	ShouldSkipNullCache(method string) bool
 }

--- a/go-proxy-cache/internal/interfaces/mock/cache.go
+++ b/go-proxy-cache/internal/interfaces/mock/cache.go
@@ -20,7 +20,6 @@ import (
 type MockCache struct {
 	ctrl     *gomock.Controller
 	recorder *MockCacheMockRecorder
-	isgomock struct{}
 }
 
 // MockCacheMockRecorder is the mock recorder for MockCache.
@@ -98,7 +97,6 @@ func (mr *MockCacheMockRecorder) Set(key, val, ttl any) *gomock.Call {
 type MockLevelAwareCache struct {
 	ctrl     *gomock.Controller
 	recorder *MockLevelAwareCacheMockRecorder
-	isgomock struct{}
 }
 
 // MockLevelAwareCacheMockRecorder is the mock recorder for MockLevelAwareCache.

--- a/go-proxy-cache/internal/interfaces/mock/cache_rules_classifier.go
+++ b/go-proxy-cache/internal/interfaces/mock/cache_rules_classifier.go
@@ -20,7 +20,6 @@ import (
 type MockCacheRulesClassifier struct {
 	ctrl     *gomock.Controller
 	recorder *MockCacheRulesClassifierMockRecorder
-	isgomock struct{}
 }
 
 // MockCacheRulesClassifierMockRecorder is the mock recorder for MockCacheRulesClassifier.
@@ -52,4 +51,18 @@ func (m *MockCacheRulesClassifier) GetTtl(chain, network string, request *models
 func (mr *MockCacheRulesClassifierMockRecorder) GetTtl(chain, network, request any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTtl", reflect.TypeOf((*MockCacheRulesClassifier)(nil).GetTtl), chain, network, request)
+}
+
+// ShouldSkipNullCache mocks base method.
+func (m *MockCacheRulesClassifier) ShouldSkipNullCache(method string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShouldSkipNullCache", method)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ShouldSkipNullCache indicates an expected call of ShouldSkipNullCache.
+func (mr *MockCacheRulesClassifierMockRecorder) ShouldSkipNullCache(method any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldSkipNullCache", reflect.TypeOf((*MockCacheRulesClassifier)(nil).ShouldSkipNullCache), method)
 }

--- a/go-proxy-cache/internal/interfaces/mock/cache_rules_config.go
+++ b/go-proxy-cache/internal/interfaces/mock/cache_rules_config.go
@@ -21,7 +21,6 @@ import (
 type MockCacheRulesConfig struct {
 	ctrl     *gomock.Controller
 	recorder *MockCacheRulesConfigMockRecorder
-	isgomock struct{}
 }
 
 // MockCacheRulesConfigMockRecorder is the mock recorder for MockCacheRulesConfig.
@@ -81,4 +80,18 @@ func (m *MockCacheRulesConfig) GetTtlForCacheType(chain, network string, cacheTy
 func (mr *MockCacheRulesConfigMockRecorder) GetTtlForCacheType(chain, network, cacheType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTtlForCacheType", reflect.TypeOf((*MockCacheRulesConfig)(nil).GetTtlForCacheType), chain, network, cacheType)
+}
+
+// ShouldSkipNullCache mocks base method.
+func (m *MockCacheRulesConfig) ShouldSkipNullCache(method string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShouldSkipNullCache", method)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ShouldSkipNullCache indicates an expected call of ShouldSkipNullCache.
+func (mr *MockCacheRulesConfigMockRecorder) ShouldSkipNullCache(method any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldSkipNullCache", reflect.TypeOf((*MockCacheRulesConfig)(nil).ShouldSkipNullCache), method)
 }

--- a/go-proxy-cache/internal/interfaces/mock/keybuilder.go
+++ b/go-proxy-cache/internal/interfaces/mock/keybuilder.go
@@ -20,7 +20,6 @@ import (
 type MockKeyBuilder struct {
 	ctrl     *gomock.Controller
 	recorder *MockKeyBuilderMockRecorder
-	isgomock struct{}
 }
 
 // MockKeyBuilderMockRecorder is the mock recorder for MockKeyBuilder.

--- a/go-proxy-cache/internal/interfaces/mock/keydb_client.go
+++ b/go-proxy-cache/internal/interfaces/mock/keydb_client.go
@@ -22,7 +22,6 @@ import (
 type MockKeyDbClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockKeyDbClientMockRecorder
-	isgomock struct{}
 }
 
 // MockKeyDbClientMockRecorder is the mock recorder for MockKeyDbClient.

--- a/go-proxy-cache/internal/utils/response_utils.go
+++ b/go-proxy-cache/internal/utils/response_utils.go
@@ -50,3 +50,25 @@ func FixResponseID(cachedResponse string, requestID interface{}) string {
 
 	return cachedResponse
 }
+
+// IsNullResult checks if the JSON-RPC response has a null result
+// This is used to skip caching null results for methods like eth_getTransactionReceipt
+// where null indicates a pending/non-existent transaction that may appear later
+func IsNullResult(responseData string) bool {
+	if responseData == "" {
+		return false
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal([]byte(responseData), &response); err != nil {
+		return false
+	}
+
+	// Check if result field exists and is null
+	result, exists := response["result"]
+	if !exists {
+		return false
+	}
+
+	return result == nil
+}

--- a/go-proxy-cache/internal/utils/response_utils_test.go
+++ b/go-proxy-cache/internal/utils/response_utils_test.go
@@ -1,0 +1,214 @@
+package utils
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestIsNullResult(t *testing.T) {
+	tests := []struct {
+		name         string
+		responseData string
+		expected     bool
+		description  string
+	}{
+		{
+			name:         "null result",
+			responseData: `{"jsonrpc":"2.0","id":1,"result":null}`,
+			expected:     true,
+			description:  "should return true when result is null",
+		},
+		{
+			name:         "non-null result - object",
+			responseData: `{"jsonrpc":"2.0","id":1,"result":{"blockNumber":"0x123"}}`,
+			expected:     false,
+			description:  "should return false when result is an object",
+		},
+		{
+			name:         "non-null result - string",
+			responseData: `{"jsonrpc":"2.0","id":1,"result":"0x123"}`,
+			expected:     false,
+			description:  "should return false when result is a string",
+		},
+		{
+			name:         "non-null result - number",
+			responseData: `{"jsonrpc":"2.0","id":1,"result":123}`,
+			expected:     false,
+			description:  "should return false when result is a number",
+		},
+		{
+			name:         "non-null result - array",
+			responseData: `{"jsonrpc":"2.0","id":1,"result":[]}`,
+			expected:     false,
+			description:  "should return false when result is an array",
+		},
+		{
+			name:         "non-null result - boolean",
+			responseData: `{"jsonrpc":"2.0","id":1,"result":true}`,
+			expected:     false,
+			description:  "should return false when result is a boolean",
+		},
+		{
+			name:         "error response",
+			responseData: `{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"Invalid Request"}}`,
+			expected:     false,
+			description:  "should return false for error response without result field",
+		},
+		{
+			name:         "empty response",
+			responseData: "",
+			expected:     false,
+			description:  "should return false for empty response",
+		},
+		{
+			name:         "invalid JSON",
+			responseData: "not valid json",
+			expected:     false,
+			description:  "should return false for invalid JSON",
+		},
+		{
+			name:         "missing result field",
+			responseData: `{"jsonrpc":"2.0","id":1}`,
+			expected:     false,
+			description:  "should return false when result field is missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsNullResult(tt.responseData)
+			if result != tt.expected {
+				t.Errorf("%s: expected %v, got %v", tt.description, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestParseJSONRPCRequest(t *testing.T) {
+	tests := []struct {
+		name        string
+		rawBody     string
+		expectError bool
+		method      string
+	}{
+		{
+			name:        "valid request",
+			rawBody:     `{"method":"eth_getBalance","params":["0x123",true],"jsonrpc":"2.0","id":1}`,
+			expectError: false,
+			method:      "eth_getBalance",
+		},
+		{
+			name:        "empty body",
+			rawBody:     "",
+			expectError: true,
+		},
+		{
+			name:        "invalid JSON",
+			rawBody:     "not valid json",
+			expectError: true,
+		},
+		{
+			name:        "missing method",
+			rawBody:     `{"params":["0x123"],"jsonrpc":"2.0","id":1}`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request, err := ParseJSONRPCRequest(tt.rawBody)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if request.Method != tt.method {
+					t.Errorf("Expected method %s, got %s", tt.method, request.Method)
+				}
+			}
+		})
+	}
+}
+
+func TestFixResponseID(t *testing.T) {
+	tests := []struct {
+		name           string
+		cachedResponse string
+		requestID      interface{}
+		expected       string
+		isValidJSON    bool // whether we expect valid JSON output
+	}{
+		{
+			name:           "fix integer ID",
+			cachedResponse: `{"jsonrpc":"2.0","id":1,"result":"0x123"}`,
+			requestID:      float64(2), // JSON numbers are decoded as float64
+			expected:       `{"id":2,"jsonrpc":"2.0","result":"0x123"}`,
+			isValidJSON:    true,
+		},
+		{
+			name:           "same ID - no change needed",
+			cachedResponse: `{"jsonrpc":"2.0","id":1,"result":"0x123"}`,
+			requestID:      float64(1),
+			expected:       `{"jsonrpc":"2.0","id":1,"result":"0x123"}`,
+			isValidJSON:    true,
+		},
+		{
+			name:           "empty response",
+			cachedResponse: "",
+			requestID:      float64(1),
+			expected:       "",
+			isValidJSON:    false,
+		},
+		{
+			name:           "nil request ID",
+			cachedResponse: `{"jsonrpc":"2.0","id":1,"result":"0x123"}`,
+			requestID:      nil,
+			expected:       `{"jsonrpc":"2.0","id":1,"result":"0x123"}`,
+			isValidJSON:    true,
+		},
+		{
+			name:           "invalid JSON",
+			cachedResponse: "not valid json",
+			requestID:      float64(1),
+			expected:       "not valid json",
+			isValidJSON:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FixResponseID(tt.cachedResponse, tt.requestID)
+
+			if tt.isValidJSON {
+				// Compare unmarshaled JSON to be insensitive to key ordering
+				var expectedMap, resultMap map[string]interface{}
+				if err := json.Unmarshal([]byte(tt.expected), &expectedMap); err != nil {
+					t.Fatalf("Failed to unmarshal expected JSON: %v", err)
+				}
+				if err := json.Unmarshal([]byte(result), &resultMap); err != nil {
+					t.Fatalf("Failed to unmarshal result JSON: %v", err)
+				}
+				if !reflect.DeepEqual(expectedMap, resultMap) {
+					t.Errorf("Expected %v, got %v", expectedMap, resultMap)
+				}
+			} else {
+				// For non-JSON cases, compare strings directly
+				if result != tt.expected {
+					t.Errorf("Expected %s, got %s", tt.expected, result)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkIsNullResult(b *testing.B) {
+	responseData := `{"jsonrpc":"2.0","id":1,"result":null}`
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		IsNullResult(responseData)
+	}
+}


### PR DESCRIPTION
When a response has result: null, the cache layer checks if the method is in the skip list and bypasses caching.

* Added skip_null_cache list in cache_rules.yaml for methods: eth_getTransactionReceipt, eth_getTransactionByHash, eth_getBlockByHash, eth_getBlockByNumber

fixes #101