### PR TITLE
feat(rpc): Add Status Network Hoodi testnet

### DIFF
--- a/rpc-health-checker/network_data.py
+++ b/rpc-health-checker/network_data.py
@@ -2,6 +2,7 @@ INFURA = "infura"
 GROVE = "grove"
 NODEFLEET = "nodefleet"
 STATUS_NETWORK = "status_network"
+STATUS_NETWORK_HOODI = "status_network_hoodi"
 ALCHEMY = "alchemy"
 KATANA = "katana"
 
@@ -211,7 +212,15 @@ NETWORK_DATA = [
         "network": "sepolia",
         "chainId": 1660990954,
         "providers": {
-            STATUS_NETWORK: "https://public.sepolia.rpc.status.network/"
+            STATUS_NETWORK: "https://public.sepolia.rpc.status.network/",
+        }
+    },
+    {
+        "chain": "status",
+        "network": "hoodi",
+        "chainId": 374,
+        "providers": {
+            STATUS_NETWORK_HOODI: "https://rpc.status-network-testnet-hoodi.gateway.fm/"
         }
     },
     {


### PR DESCRIPTION
Adds `status_network_hoodi` (chainId 374) as a separate chain (`status/hoodi`). The hoodi testnet has a different chainId (`0x176` = 374) vs sepolia (`0x6300b5ea` = 1660990954).

**Infra: regenerate providers** (add `status_network_hoodi` to `--providers` and `hoodi` to `--networks`):

```bash
python3 generate_providers.py \
  --providers ... status_network_hoodi \
  --networks ... hoodi \
  --chains <unchanged> \
  --output secrets/default_providers.json

python3 generate_providers.py --single-provider \
  --providers ... status_network_hoodi \
  --networks ... hoodi \
  --chains <unchanged> \
  --output secrets/reference_providers.json
```

**Verify:**

```bash
# Start local env
./start-local.sh

# Get token and call hoodi
TOKEN="$(bash <(curl -fsSL https://raw.githubusercontent.com/status-im/proxy-common/master/scripts/get_proxy_token.sh) http://localhost:8081)"
curl -sS -X POST http://localhost:8080/status/hoodi \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer ${TOKEN}" \
  -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
# → {"jsonrpc":"2.0","id":1,"result":"0x28c29"}
```