### PR TITLE
feat(health-checker): support query parameter provider auth

### DIFF
--- a/rpc-health-checker/generate_providers.py
+++ b/rpc-health-checker/generate_providers.py
@@ -4,7 +4,14 @@ from collections import defaultdict
 from network_data import NETWORK_DATA
 
 def parse_provider_spec(provider_spec):
-    """Parse provider specification into provider type and auth details."""
+    """Parse provider specification into provider type and auth details.
+    
+    Formats:
+        provider                     -> no-auth
+        provider:token               -> token-auth (token appended to URL path)
+        provider:?param=token        -> key-query-auth (token added as ?param=token query)
+        provider:username:password   -> basic-auth
+    """
     parts = provider_spec.split(":", 2)
 
     if len(parts) == 1:
@@ -13,28 +20,40 @@ def parse_provider_spec(provider_spec):
             "auth_type": "no-auth",
             "auth_token": "",
             "auth_login": "",
-            "auth_password": ""
+            "auth_password": "",
+            "key_query_param": ""
         }
 
     provider_type = parts[0]
 
     if len(parts) == 2:
-        # Token auth format: provider:token
+        token_part = parts[1]
+        if token_part.startswith("?") and "=" in token_part:
+            param_name, _, token_value = token_part[1:].partition("=")
+            return {
+                "type": provider_type,
+                "auth_type": "key-query-auth",
+                "auth_token": token_value,
+                "auth_login": "",
+                "auth_password": "",
+                "key_query_param": param_name
+            }
         return {
             "type": provider_type,
             "auth_type": "token-auth",
-            "auth_token": parts[1],
+            "auth_token": token_part,
             "auth_login": "",
-            "auth_password": ""
+            "auth_password": "",
+            "key_query_param": ""
         }
     else:
-        # Basic auth format: provider:username:password
         return {
             "type": provider_type,
             "auth_type": "basic-auth",
             "auth_token": "",
             "auth_login": parts[1],
-            "auth_password": parts[2]
+            "auth_password": parts[2],
+            "key_query_param": ""
         }
 
 def create_provider_entry(p_type, provider_spec, network_data, count=None):
@@ -43,7 +62,8 @@ def create_provider_entry(p_type, provider_spec, network_data, count=None):
     chain_name = network_data["chain"].capitalize()
     network_name = network_data["network"].capitalize()
     name = f"{base_name} {chain_name} {network_name}"
-    return {
+
+    entry = {
         "type": p_type,
         "name": name,
         "url": network_data["providers"][p_type],
@@ -51,8 +71,13 @@ def create_provider_entry(p_type, provider_spec, network_data, count=None):
         "authToken": provider_spec["auth_token"],
         "authLogin": provider_spec["auth_login"],
         "authPassword": provider_spec["auth_password"],
-        "chainId": network_data["chainId"]
+        "chainId": network_data["chainId"],
     }
+
+    if provider_spec["key_query_param"]:
+        entry["keyQueryParam"] = provider_spec["key_query_param"]
+
+    return entry
 
 def create_chain_entry(network_data):
     """Create a base chain entry with consistent format."""
@@ -147,7 +172,7 @@ def main():
     
     parser = argparse.ArgumentParser(description="Generate providers.json configuration")
     parser.add_argument("--providers", nargs="+", required=True,
-                        help=f"Provider specification formats: provider (no auth), provider:token (token auth), or provider:username:password (basic auth). Supported providers: {', '.join(supported_providers)}")
+                        help=f"Provider specification formats: provider (no auth), provider:token (token auth), provider:?param=token (query param auth), or provider:username:password (basic auth). Supported providers: {', '.join(supported_providers)}")
     parser.add_argument("--networks", nargs="+", required=True,
                         choices=supported_networks,
                         help="Networks to generate configs for")

--- a/rpc-health-checker/network_data.py
+++ b/rpc-health-checker/network_data.py
@@ -15,8 +15,8 @@ NETWORK_DATA = [
             INFURA: "https://mainnet.infura.io/v3/",
             GROVE: "https://eth.rpc.grove.city/v1/",
             NODEFLEET: "https://eth-mainnet.alphafleet.io/",
-            ALCHEMY: "https://eth-mainnet.g.alchemy.com/v2/"
-        }
+            ALCHEMY: "https://eth-mainnet.g.alchemy.com/v2/",
+        },
     },
     {
         "chain": "ethereum",

--- a/rpc-health-checker/provider/provider.go
+++ b/rpc-health-checker/provider/provider.go
@@ -4,22 +4,24 @@ package provider
 type RPCProviderAuthType string
 
 const (
-	NoAuth    RPCProviderAuthType = "no-auth"    // No authentication
-	BasicAuth RPCProviderAuthType = "basic-auth" // HTTP Header "Authorization: Basic base64(username:password)"
-	TokenAuth RPCProviderAuthType = "token-auth" // URL Token-based authentication "https://api.example.com/YOUR_TOKEN"
+	NoAuth       RPCProviderAuthType = "no-auth"        // No authentication
+	BasicAuth    RPCProviderAuthType = "basic-auth"      // HTTP Header "Authorization: Basic base64(username:password)"
+	TokenAuth    RPCProviderAuthType = "token-auth"      // URL Token-based authentication "https://api.example.com/YOUR_TOKEN"
+	KeyQueryAuth RPCProviderAuthType = "key-query-auth"  // Query parameter authentication "https://api.example.com/?key=YOUR_TOKEN"
 )
 
 // RPCProvider represents the configuration of an RPC provider with various options
 type RPCProvider struct {
-	Type         string              `json:"type" validate:"required,min=1"`                                          // Provider type (infura, alchemy, etc)
-	Name         string              `json:"name" validate:"required,min=1"`                                          // Provider name for identification
-	URL          string              `json:"url" validate:"required,url"`                                             // URL of the current provider
-	AuthType     RPCProviderAuthType `json:"authType" validate:"required,oneof=no-auth basic-auth token-auth"`        // Authentication type
-	AuthLogin    string              `json:"authLogin" validate:"required_if=AuthType basic-auth,omitempty,min=1"`    // Login for BasicAuth
-	AuthPassword string              `json:"authPassword" validate:"required_if=AuthType basic-auth,omitempty,min=1"` // Password for BasicAuth
-	AuthToken    string              `json:"authToken" validate:"required_if=AuthType token-auth,omitempty,min=1"`    // Token for TokenAuth
-	ChainID      int64               `json:"chainId" validate:"required,gt=0"`                                        // Chain ID of the network
-	ChainName    string              `json:"chainName,omitempty"`                                                     // Chain name for metrics
+	Type          string              `json:"type" validate:"required,min=1"`                                                          // Provider type (infura, alchemy, etc)
+	Name          string              `json:"name" validate:"required,min=1"`                                                          // Provider name for identification
+	URL           string              `json:"url" validate:"required,url"`                                                             // URL of the current provider
+	AuthType      RPCProviderAuthType `json:"authType" validate:"required,oneof=no-auth basic-auth token-auth key-query-auth"`         // Authentication type
+	AuthLogin     string              `json:"authLogin" validate:"required_if=AuthType basic-auth,omitempty,min=1"`                    // Login for BasicAuth
+	AuthPassword  string              `json:"authPassword" validate:"required_if=AuthType basic-auth,omitempty,min=1"`                 // Password for BasicAuth
+	AuthToken     string              `json:"authToken" validate:"required_if=AuthType token-auth,required_if=AuthType key-query-auth,omitempty,min=1"` // Token for TokenAuth and KeyQueryAuth
+	KeyQueryParam string              `json:"keyQueryParam,omitempty" validate:"required_if=AuthType key-query-auth,omitempty,min=1"`  // Query parameter name for KeyQueryAuth
+	ChainID       int64               `json:"chainId" validate:"required,gt=0"`                                                        // Chain ID of the network
+	ChainName     string              `json:"chainName,omitempty"`                                                                     // Chain name for metrics
 }
 
 // method unmarshal json and validate field "Enabled" exists

--- a/rpc-health-checker/provider/provider_utils_test.go
+++ b/rpc-health-checker/provider/provider_utils_test.go
@@ -17,6 +17,7 @@ type RpcProviderTestSuite struct {
 	validJSON           string
 	invalidJSON         string
 	invalidAuthTypeJSON string
+	invalidKeyQueryJSON string
 }
 
 // SetupSuite is executed before running all tests in the suite
@@ -79,6 +80,17 @@ func (suite *RpcProviderTestSuite) SetupSuite() {
 			"authType": "invalid-auth"
 		}]
 	}`
+
+	suite.invalidKeyQueryJSON = `{
+		"providers": [{
+			"type": "status_network_hoodi",
+			"name": "StatusHoodi",
+			"url": "https://rpc.status-network-testnet-hoodi.gateway.fm/",
+			"authType": "key-query-auth",
+			"authToken": "test-token",
+			"chainId": 374
+		}]
+	}`
 }
 
 // TearDownSuite is executed after all tests in the suite
@@ -126,6 +138,33 @@ func (suite *RpcProviderTestSuite) TestReadRpcProvidersSuccess() {
 	suite.Equal("infura-token", first.AuthToken, "First provider AuthToken mismatch")
 }
 
+func (suite *RpcProviderTestSuite) TestReadRpcProvidersKeyQueryAuthSuccess() {
+	keyQueryJSON := `{
+  "providers": [
+    {
+      "type": "status_network_hoodi",
+      "name": "StatusHoodi",
+      "url": "https://rpc.status-network-testnet-hoodi.gateway.fm/",
+      "authType": "key-query-auth",
+      "authToken": "test-token",
+      "keyQueryParam": "api_key",
+      "chainId": 374
+    }
+  ]
+}`
+	err := os.WriteFile(suite.tempFile, []byte(keyQueryJSON), 0644)
+	suite.Require().NoError(err, "Failed to write key-query auth JSON to temp file")
+
+	providers, err := ReadRpcProviders(suite.tempFile)
+	suite.Require().NoError(err, "ReadRpcProviders() returned an error")
+	suite.Require().Len(providers, 1)
+
+	p := providers[0]
+	suite.Equal(KeyQueryAuth, p.AuthType)
+	suite.Equal("api_key", p.KeyQueryParam)
+	suite.Equal("test-token", p.AuthToken)
+}
+
 // TestReadRpcProvidersFileNotFound checks that the function returns an error for a non-existent file
 func (suite *RpcProviderTestSuite) TestReadRpcProvidersFileNotFound() {
 	_, err := ReadRpcProviders(filepath.Join(suite.tempDir, "non_existent.json"))
@@ -151,6 +190,14 @@ func (suite *RpcProviderTestSuite) TestInvalidAuthTypeJSON() {
 	// Attempt to read providers from the file
 	_, err = ReadRpcProviders(suite.tempFile)
 	suite.Error(err, "Expected JSON parse error")
+}
+
+func (suite *RpcProviderTestSuite) TestInvalidKeyQueryAuthJSON() {
+	err := os.WriteFile(suite.tempFile, []byte(suite.invalidKeyQueryJSON), 0644)
+	suite.Require().NoError(err, "Failed to write invalid key-query auth JSON to temp file")
+
+	_, err = ReadRpcProviders(suite.tempFile)
+	suite.Error(err, "Expected validation error for missing keyQueryParam")
 }
 
 // TestWriteRpcProvidersAndReadBack checks that writing and subsequent reading of providers works correctly

--- a/rpc-health-checker/requests_runner/method_caller_impl.go
+++ b/rpc-health-checker/requests_runner/method_caller_impl.go
@@ -91,6 +91,10 @@ func (r *RequestsRunner) CallMethod(
 		req.SetBasicAuth(provider.AuthLogin, provider.AuthPassword)
 	case rpcprovider.TokenAuth:
 		req.URL.Path = strings.TrimRight(req.URL.Path, "/") + fmt.Sprintf("/%s", provider.AuthToken)
+	case rpcprovider.KeyQueryAuth:
+		q := req.URL.Query()
+		q.Set(provider.KeyQueryParam, provider.AuthToken)
+		req.URL.RawQuery = q.Encode()
 	}
 
 	// Make the request

--- a/rpc-health-checker/requests_runner/parallel_requests_test.go
+++ b/rpc-health-checker/requests_runner/parallel_requests_test.go
@@ -476,6 +476,37 @@ func TestCallEVMMethod(t *testing.T) {
 			wantResult:  "0x1",
 		},
 		{
+			name: "Successful KeyQueryAuth request",
+			provider: provider.RPCProvider{
+				Name:          "test",
+				URL:           "", // Will be set to test server URL
+				AuthType:      provider.KeyQueryAuth,
+				AuthToken:     "test-token",
+				KeyQueryParam: "api_key",
+			},
+			method: "eth_chainId",
+			params: []interface{}{},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "test-token", r.URL.Query().Get("api_key"))
+				assert.Empty(t, r.Header.Get("Authorization"))
+
+				var req map[string]interface{}
+				err := json.NewDecoder(r.Body).Decode(&req)
+				assert.NoError(t, err)
+				assert.Equal(t, "2.0", req["jsonrpc"])
+				assert.Equal(t, "eth_chainId", req["method"])
+				assert.Equal(t, []interface{}{}, req["params"])
+				assert.Equal(t, float64(1), req["id"])
+
+				w.WriteHeader(http.StatusOK)
+				if _, err := w.Write([]byte(`{"jsonrpc":"2.0","result":"0x1"}`)); err != nil {
+					t.Errorf("failed to write response: %v", err)
+				}
+			},
+			wantSuccess: true,
+			wantResult:  "0x1",
+		},
+		{
 			name: "Server error response",
 			provider: provider.RPCProvider{
 				Name:     "test",


### PR DESCRIPTION
fixes #117 
Support the new auth type:
```
python3 generate_providers.py \
   --single-provider \
   --providers status_network_hoodi:?api_key=KEY \
   --networks hoodi \
   --chains status 
   ```