### PR TITLE
feat(rpc): add Robinhood Chain mainnet and testnet

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,33 @@
+# eth-rpc-proxy
+
+Glossary for how this proxy names and relates chains, networks, and RPC providers.
+
+## Language
+
+**Chain**:
+The blockchain product slug used in the public URL path `/{chain}/{network}` (e.g. `ethereum`, `robinhood`).
+_Avoid_: Network (when meaning the product), chain name, brand
+
+**Network**:
+The deployment environment of a Chain (e.g. `mainnet`, `sepolia`, `testnet`, `hoodi`).
+_Avoid_: Chain (when meaning the environment), testnet/mainnet as a product name
+
+**Chain/network pair**:
+A concrete routable target identified by `chain` + `network` and a numeric `chainId` (e.g. `robinhood/mainnet` = 4663).
+_Avoid_: Chain alone, network alone, chain ID alone when referring to a route
+
+**Provider type**:
+A named class of RPC backend (e.g. `infura`, `alchemy`, `robinhood`) with a shared auth model and URL template.
+_Avoid_: Provider (when meaning the type rather than an instance), vendor, backend
+
+**Default provider**:
+A candidate RPC endpoint listed for a chain/network pair that the proxy may use after health validation.
+_Avoid_: Provider list entry, upstream
+
+**Reference provider**:
+The ground-truth endpoint for a chain/network pair against which other Default providers are compared during health checks.
+_Avoid_: Primary provider, oracle, source of truth (as a synonym for the config role)
+
+**Auto-approve**:
+When a Default provider has the same Provider type as the Reference provider, it is treated as valid without cross-checking responses.
+_Avoid_: Skip validation, trust same type

--- a/README.md
+++ b/README.md
@@ -19,24 +19,24 @@ Run the complete system:
    
    # Generate default_providers.json with different authentication methods
    python3 rpc-health-checker/generate_providers.py \
-     --providers infura:YOUR_INFURA_TOKEN grove:YOUR_GROVE_TOKEN alchemy:YOUR_ALCHEMY_TOKEN status_network \
-     --networks mainnet sepolia \
-     --chains ethereum optimism arbitrum base status \
+     --providers infura:YOUR_INFURA_TOKEN grove:YOUR_GROVE_TOKEN alchemy:YOUR_ALCHEMY_TOKEN status_network robinhood \
+     --networks mainnet sepolia testnet \
+     --chains ethereum optimism arbitrum base status robinhood \
      --output secrets/default_providers.json
    
    # Or use mix of token, basic auth, and no-auth providers
    python3 rpc-health-checker/generate_providers.py \
-     --providers infura:YOUR_INFURA_TOKEN grove:username:password alchemy:YOUR_ALCHEMY_TOKEN status_network \
-     --networks mainnet sepolia \
-     --chains ethereum optimism arbitrum base status \
+     --providers infura:YOUR_INFURA_TOKEN grove:username:password alchemy:YOUR_ALCHEMY_TOKEN status_network robinhood \
+     --networks mainnet sepolia testnet \
+     --chains ethereum optimism arbitrum base status robinhood \
      --output secrets/default_providers.json
      
    # Generate reference_providers.json with single provider per chain
    python3 rpc-health-checker/generate_providers.py \
      --single-provider \
-     --providers infura:YOUR_INFURA_TOKEN_REFERENCE alchemy:YOUR_ALCHEMY_TOKEN status_network \
-     --networks mainnet sepolia \
-     --chains ethereum optimism arbitrum base status \
+     --providers infura:YOUR_INFURA_TOKEN_REFERENCE alchemy:YOUR_ALCHEMY_TOKEN status_network robinhood \
+     --networks mainnet sepolia testnet \
+     --chains ethereum optimism arbitrum base status robinhood \
      --output secrets/reference_providers.json
     ``` 
    Please replace:

--- a/docs/ADD_NEW_CHAINS.md
+++ b/docs/ADD_NEW_CHAINS.md
@@ -6,23 +6,23 @@ This guide explains how to add new blockchain networks to the eth-rpc-proxy syst
 
 The eth-rpc-proxy system supports multiple blockchain networks and provides fallback functionality between different RPC providers. When adding a new chain, you need to:
 
-1. Update the `generate_providers.py` script with the new chain information
+1. Update `network_data.py` with the new chain information
 2. Generate the updated providers configuration files
 3. Test the proxy with the new chains
 
 ```mermaid
 flowchart TD
-    A[Add endpoints to generate_providers.py] --> B[Generate default_providers.json and reference_providers.json]
+    A[Add endpoints to network_data.py] --> B[Generate default_providers.json and reference_providers.json]
     B --> C[Run proxy locally and test with Curl]
 ```
 
-## Step 1: Update the `generate_providers.py` Script
+## Step 1: Update `network_data.py`
 
-The `generate_providers.py` script contains a `NETWORK_DATA` array that defines all supported chains. To add a new chain:
+The `NETWORK_DATA` array in `rpc-health-checker/network_data.py` is the canonical source of supported chains. To add a new chain:
 
-1. Open `rpc-health-checker/generate_providers.py`
+1. Open `rpc-health-checker/network_data.py`
 2. Add new entries to the `NETWORK_DATA` array for your chain (both mainnet and testnet if applicable)
-3. The script will automatically generate the choices for both `--chains` and `--networks` parameters from the `NETWORK_DATA` array, and will update the help text for `--providers` to include all supported provider types
+3. `generate_providers.py` will automatically generate the choices for both `--chains` and `--networks` from `NETWORK_DATA`, and will update the help text for `--providers` to include all supported provider types
 
 Example of adding a new chain:
 
@@ -67,17 +67,18 @@ python3 rpc-health-checker/generate_providers.py \
                nodefleet:STATUS_USER:STATUS_PASSWORD \
                infura:INFURA_TOKEN \
                status_network \
-   --networks mainnet sepolia \
-   --chains ethereum optimism arbitrum base status NEW_CHAIN_HERE \
+               robinhood \
+   --networks mainnet sepolia testnet \
+   --chains ethereum optimism arbitrum base status robinhood NEW_CHAIN_HERE \
    --output secrets/default_providers.json
 
 
 # reference_providers.json 
 python3 rpc-health-checker/generate_providers.py \
    --single-provider \
-   --providers infura:INFURA_REF_TOKEN status_network \
-   --networks mainnet sepolia \
-   --chains ethereum optimism arbitrum base status NEW_CHAIN_HERE \
+   --providers infura:INFURA_REF_TOKEN status_network robinhood \
+   --networks mainnet sepolia testnet \
+   --chains ethereum optimism arbitrum base status robinhood NEW_CHAIN_HERE \
    --output secrets/reference_providers.json
 ```
 
@@ -131,4 +132,3 @@ curl -X POST http://localhost:8080/NEW_CHAIN/mainnet \
 ```
 
 Make sure to replace `your_username` and `your_password` with the credentials you set up in the `.htpasswd` file.
-

--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -2,10 +2,20 @@
 
 After adding new chains (see [ADD_NEW_CHAINS.md](ADD_NEW_CHAINS.md)), update the test server:
 
+- [ ] **Enable the new networks in Infura and Alchemy dashboards before deploy.**
+  Until Infura and Alchemy accept the chain, the proxy falls through to any
+  public/no-auth backup provider. For Robinhood that means 100% of traffic
+  hits Robinhood's rate-limited public RPC (no SLA); when that returns 429
+  there is no further fallback and clients get 502.
+  - Infura: enable Robinhood mainnet (`robinhood-mainnet.infura.io`) and
+    testnet (`robinhood-testnet.infura.io`) on the project. Verify with
+    `eth_chainId` → `0x1237` (4663) / `0xb626` (46630).
+  - Alchemy: enable `ROBINHOOD_MAINNET` and `ROBINHOOD_TESTNET` on the app
+    (dashboard → app → Networks). Same `eth_chainId` checks as above.
 - [ ] Create ticket in [infra-proxy](https://github.com/status-im/infra-proxy)
    - Enable new chains in all affected RPC provider dashboards 
    - Add new chains to the eth-rpc-proxy-setup
    - *Optional: Create PR in infra-proxy with [new chains](@https://github.com/status-im/infra-proxy/blob/643054f1c2359a7ac02202f1f9d3cf6ec9e4af87/ansible/roles/eth-rpc-proxy-setup/tasks/setup.yml#L30)
 - [ ] Notify infra-team in #infra-discussion channel
 - [ ] Push to `deploy-test` branch to trigger server redeploy
-- [ ] *Verify new chains are accessible with CURL 
+- [ ] *Verify new chains are accessible with CURL

--- a/rpc-health-checker/network_data.py
+++ b/rpc-health-checker/network_data.py
@@ -5,6 +5,7 @@ STATUS_NETWORK = "status_network"
 STATUS_NETWORK_HOODI = "status_network_hoodi"
 ALCHEMY = "alchemy"
 KATANA = "katana"
+ROBINHOOD = "robinhood"
 
 NETWORK_DATA = [
     {
@@ -354,5 +355,25 @@ NETWORK_DATA = [
             INFURA: "https://scroll-sepolia.infura.io/v3/",
             ALCHEMY: "https://scroll-sepolia.g.alchemy.com/v2/"
         }
-    }
+    },
+    {
+        "chain": "robinhood",
+        "network": "mainnet",
+        "chainId": 4663,
+        "providers": {
+            INFURA: "https://robinhood-mainnet.infura.io/v3/",
+            ALCHEMY: "https://robinhood-mainnet.g.alchemy.com/v2/",
+            ROBINHOOD: "https://rpc.mainnet.chain.robinhood.com/",
+        }
+    },
+    {
+        "chain": "robinhood",
+        "network": "testnet",
+        "chainId": 46630,
+        "providers": {
+            INFURA: "https://robinhood-testnet.infura.io/v3/",
+            ALCHEMY: "https://robinhood-testnet.g.alchemy.com/v2/",
+            ROBINHOOD: "https://rpc.testnet.chain.robinhood.com/",
+        }
+    },
 ]

--- a/rpc-health-checker/test_methods.json
+++ b/rpc-health-checker/test_methods.json
@@ -2,7 +2,8 @@
   {
     "method": "eth_blockNumber",
     "params": [],
-    "maxDifference": "4"
+    "maxDifference": "4",
+    "skipChains": [4663, 46630]
   },
   {
     "method": "eth_getTransactionCount",

--- a/test-api/src/utils/apiUtils.js
+++ b/test-api/src/utils/apiUtils.js
@@ -77,7 +77,9 @@ export const AVAILABLE_NETWORKS = [
   { value: 'bsc/mainnet', label: 'BSC Mainnet', chainId: 56 },
   { value: 'bsc/testnet', label: 'BSC Testnet', chainId: 97 },
   { value: 'polygon/mainnet', label: 'Polygon Mainnet', chainId: 137 },
-  { value: 'polygon/amoy', label: 'Polygon Amoy', chainId: 80002 }
+  { value: 'polygon/amoy', label: 'Polygon Amoy', chainId: 80002 },
+  { value: 'robinhood/mainnet', label: 'Robinhood Chain', chainId: 4663 },
+  { value: 'robinhood/testnet', label: 'Robinhood Chain Testnet', chainId: 46630 }
 ];
 
 /**


### PR DESCRIPTION
Add robinhood/mainnet (4663) and robinhood/testnet (46630) with Infura, Alchemy, and Robinhood public RPC failover. Skip eth_blockNumber health checks for these fast L2s and gate deploy on enabling the networks in provider dashboards.