### PR TITLE
fix(rpc): drop Infura for Robinhood, require Alchemy reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Run the complete system:
      --networks mainnet sepolia testnet \
      --chains ethereum optimism arbitrum base status robinhood \
      --output secrets/reference_providers.json
+    # Robinhood has no Infura endpoint; Alchemy must be present so it becomes
+    # the reference for robinhood/* (first matching provider type wins).
     ``` 
    Please replace:
    - `YOUR_INFURA_TOKEN` and `YOUR_INFURA_TOKEN_REFERENCE` with your Infura API tokens

--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ Run the complete system:
      --networks mainnet sepolia testnet \
      --chains ethereum optimism arbitrum base status robinhood \
      --output secrets/reference_providers.json
-    # Robinhood has no Infura endpoint; Alchemy must be present so it becomes
-    # the reference for robinhood/* (first matching provider type wins).
     ``` 
+
    Please replace:
    - `YOUR_INFURA_TOKEN` and `YOUR_INFURA_TOKEN_REFERENCE` with your Infura API tokens
    - `YOUR_GROVE_TOKEN` with your Grove API token, or use `username:password` for basic auth

--- a/docs/ADD_NEW_CHAINS.md
+++ b/docs/ADD_NEW_CHAINS.md
@@ -73,10 +73,12 @@ python3 rpc-health-checker/generate_providers.py \
    --output secrets/default_providers.json
 
 
-# reference_providers.json 
+# reference_providers.json
+# Note: Robinhood has no Infura endpoint — Alchemy must be listed so it can
+# become the reference for robinhood/* (first matching provider type wins).
 python3 rpc-health-checker/generate_providers.py \
    --single-provider \
-   --providers infura:INFURA_REF_TOKEN status_network robinhood \
+   --providers infura:INFURA_REF_TOKEN alchemy:ALCHEMY_TOKEN status_network robinhood \
    --networks mainnet sepolia testnet \
    --chains ethereum optimism arbitrum base status robinhood NEW_CHAIN_HERE \
    --output secrets/reference_providers.json

--- a/docs/ADD_NEW_CHAINS.md
+++ b/docs/ADD_NEW_CHAINS.md
@@ -74,8 +74,6 @@ python3 rpc-health-checker/generate_providers.py \
 
 
 # reference_providers.json
-# Note: Robinhood has no Infura endpoint — Alchemy must be listed so it can
-# become the reference for robinhood/* (first matching provider type wins).
 python3 rpc-health-checker/generate_providers.py \
    --single-provider \
    --providers infura:INFURA_REF_TOKEN alchemy:ALCHEMY_TOKEN status_network robinhood \

--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -2,16 +2,17 @@
 
 After adding new chains (see [ADD_NEW_CHAINS.md](ADD_NEW_CHAINS.md)), update the test server:
 
-- [ ] **Enable the new networks in Infura and Alchemy dashboards before deploy.**
-  Until Infura and Alchemy accept the chain, the proxy falls through to any
-  public/no-auth backup provider. For Robinhood that means 100% of traffic
-  hits Robinhood's rate-limited public RPC (no SLA); when that returns 429
-  there is no further fallback and clients get 502.
-  - Infura: enable Robinhood mainnet (`robinhood-mainnet.infura.io`) and
-    testnet (`robinhood-testnet.infura.io`) on the project. Verify with
-    `eth_chainId` → `0x1237` (4663) / `0xb626` (46630).
+- [ ] **Enable Robinhood on Alchemy before deploy.** Infura does not support
+  this chain. Providers are Alchemy → Robinhood public RPC. Until Alchemy
+  accepts the network, 100% of traffic hits Robinhood's rate-limited public
+  RPC (no SLA); when that returns 429 there is no further fallback and
+  clients get 502.
   - Alchemy: enable `ROBINHOOD_MAINNET` and `ROBINHOOD_TESTNET` on the app
-    (dashboard → app → Networks). Same `eth_chainId` checks as above.
+    (dashboard → app → Networks). Verify with `eth_chainId` → `0x1237`
+    (4663) / `0xb626` (46630).
+  - Reference provider for Robinhood must be Alchemy (not Infura). If the
+    reference task lists Infura first and omits Alchemy, Robinhood gets no
+    reference entry, the health checker skips it, and the proxy returns 404.
 - [ ] Create ticket in [infra-proxy](https://github.com/status-im/infra-proxy)
    - Enable new chains in all affected RPC provider dashboards 
    - Add new chains to the eth-rpc-proxy-setup

--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -2,17 +2,6 @@
 
 After adding new chains (see [ADD_NEW_CHAINS.md](ADD_NEW_CHAINS.md)), update the test server:
 
-- [ ] **Enable Robinhood on Alchemy before deploy.** Infura does not support
-  this chain. Providers are Alchemy → Robinhood public RPC. Until Alchemy
-  accepts the network, 100% of traffic hits Robinhood's rate-limited public
-  RPC (no SLA); when that returns 429 there is no further fallback and
-  clients get 502.
-  - Alchemy: enable `ROBINHOOD_MAINNET` and `ROBINHOOD_TESTNET` on the app
-    (dashboard → app → Networks). Verify with `eth_chainId` → `0x1237`
-    (4663) / `0xb626` (46630).
-  - Reference provider for Robinhood must be Alchemy (not Infura). If the
-    reference task lists Infura first and omits Alchemy, Robinhood gets no
-    reference entry, the health checker skips it, and the proxy returns 404.
 - [ ] Create ticket in [infra-proxy](https://github.com/status-im/infra-proxy)
    - Enable new chains in all affected RPC provider dashboards 
    - Add new chains to the eth-rpc-proxy-setup

--- a/rpc-health-checker/network_data.py
+++ b/rpc-health-checker/network_data.py
@@ -361,7 +361,6 @@ NETWORK_DATA = [
         "network": "mainnet",
         "chainId": 4663,
         "providers": {
-            INFURA: "https://robinhood-mainnet.infura.io/v3/",
             ALCHEMY: "https://robinhood-mainnet.g.alchemy.com/v2/",
             ROBINHOOD: "https://rpc.mainnet.chain.robinhood.com/",
         }
@@ -371,7 +370,6 @@ NETWORK_DATA = [
         "network": "testnet",
         "chainId": 46630,
         "providers": {
-            INFURA: "https://robinhood-testnet.infura.io/v3/",
             ALCHEMY: "https://robinhood-testnet.g.alchemy.com/v2/",
             ROBINHOOD: "https://rpc.testnet.chain.robinhood.com/",
         }

--- a/test-api/src/utils/apiUtils.js
+++ b/test-api/src/utils/apiUtils.js
@@ -78,7 +78,7 @@ export const AVAILABLE_NETWORKS = [
   { value: 'bsc/testnet', label: 'BSC Testnet', chainId: 97 },
   { value: 'polygon/mainnet', label: 'Polygon Mainnet', chainId: 137 },
   { value: 'polygon/amoy', label: 'Polygon Amoy', chainId: 80002 },
-  { value: 'robinhood/mainnet', label: 'Robinhood Chain', chainId: 4663 },
+  { value: 'robinhood/mainnet', label: 'Robinhood Chain Mainnet', chainId: 4663 },
   { value: 'robinhood/testnet', label: 'Robinhood Chain Testnet', chainId: 46630 }
 ];
 


### PR DESCRIPTION
Infura does not support Robinhood Chain. Use Alchemy with the public RPC as failover, and document that reference generation must include Alchemy so robinhood/* is not skipped by the health checker.